### PR TITLE
Pass creds and output directory as options

### DIFF
--- a/src/review_gator/clicklib.py
+++ b/src/review_gator/clicklib.py
@@ -1,0 +1,34 @@
+from click import Option, UsageError
+
+
+class NotRequiredIf(Option):
+    def __init__(self, *args, **kwargs):
+        self.mutually_exclusive = set(kwargs.pop('mutually_exclusive', []))
+        help = kwargs.get('help', '')
+        if self.mutually_exclusive:
+            ex_str = ', '.join(self.mutually_exclusive)
+            kwargs['help'] = "{} NOTE: This argument is mutually exclusive " \
+                             "with arguments: [{}].".format(help, ex_str)
+
+        super(NotRequiredIf, self).__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        we_are_present = self.name in opts
+        other_present = self.mutually_exclusive.intersection(opts)
+        if self.required and other_present:
+            if we_are_present:
+                raise UsageError(
+                        "Illegal usage: `{}` is mutually exclusive with "
+                        "arguments `{}`.".format(
+                                self.name,
+                                ', '.join(self.mutually_exclusive)
+                        )
+                )
+            else:
+                self.required = False
+
+        return super(NotRequiredIf, self).handle_parse_result(
+            ctx,
+            opts,
+            args
+        )

--- a/src/review_gator/clicklib.py
+++ b/src/review_gator/clicklib.py
@@ -1,3 +1,10 @@
+"""
+Click Option class to help make options required if other optional
+option is unset
+
+https://stackoverflow.com/questions/44247099/click-command-line-interfaces-make-options-required-if-other-optional-option-is/44349292
+"""
+
 from click import Option, UsageError
 
 

--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -259,16 +259,13 @@ def get_repo_data(repos):
     return repo_data
 
 
-def render(repos, output_directory=None):
+def render(repos, output_directory):
     '''Render the repositories into an html file.'''
     data = get_repo_data(repos)
     abs_templates_path = os.path.join(os.path.dirname(
             os.path.realpath(__file__)), "templates")
     env = Environment(loader=FileSystemLoader(abs_templates_path))
     tmpl = env.get_template('reviews.html')
-    if not output_directory:
-        output_directory = os.environ.get('SNAP_USER_COMMON',
-                                          "/tmp/review_gator/")
 
     # Make sure the output directory exists
     os.makedirs(output_directory, exist_ok=True)


### PR DESCRIPTION
All github creds can now be passed as options or environment variables.

--config-skeleton no longer requires --config to be set
--output-directory set the directory for the review.html to be saved to.

You can still use environment variables to specify github creds. 
