### PR TITLE
Use alternative method to delete from list following exception in Git…

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -95,9 +95,9 @@ class PullRequest(object):
 
     def add_review(self, review):
         '''Adds a review, replacing any older review by the same owner.'''
-        for r in self.reviews:
+        for idx, r in enumerate(self.reviews):
             if review.owner == r['owner'] and review.date > r['date']:
-                self.reviews.remove(r)
+                del self.reviews[idx]
                 break
         self.reviews.append(merge_two_dicts(review.__dict__,
                                             {'age': review.age}))
@@ -143,9 +143,11 @@ class Review(object):
 
 
 class GithubReview(Review):
+
     '''A github pull request review.'''
     def __init__(self, handle, url, owner, state, date):
         date = pytz.utc.localize(date)
+
         super(GithubReview, self).__init__(
             'github', handle, url, owner, state, date)
 


### PR DESCRIPTION
…hub module

When trying to remove an item from the list and the item contains a GitHubPullRequestReview object
then it will raise an exception in github.GithubObject.CompletableGithubObject#__eq__ due to no _url_ property.

This MP uses an alternative method of remove an item from a list, specifically using the index rather than
comparing items in the list.