### PR TITLE
Don't display negative ages

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -166,6 +166,11 @@ def date_to_age(date):
         return None
 
     age = NOW - date
+    if age < datetime.timedelta():
+        # A negative timedelta means the time is in the future; this will be
+        # due to inconsistent clocks across systems, so assume that there is no
+        # delta
+        age = datetime.timedelta()
     return humanize.naturaltime(age)
 
 


### PR DESCRIPTION
This can happen if we generate immediately after an event has happened
and our clock is behind the clock of the system that generated the
event.