### PR TITLE
Late import the launchpad lib.

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -16,7 +16,6 @@ from babel.dates import format_datetime
 from jinja2 import Environment, FileSystemLoader
 from pkg_resources import resource_filename
 
-from . import launchpadagent
 from . import clicklib
 
 MAX_DESCRIPTION_LENGTH = 80
@@ -465,6 +464,9 @@ def aggregate_reviews(sources, output_directory, github_password, github_token,
         if 'lp-git' in sources:
             repos.extend(get_lp_repos(sources['lp-git']))
         if 'launchpad' in sources:
+            # Only import the launchpad code conditionally. This prevents having an
+            # install time dependency on launchpad libs.
+            from . import launchpadagent
             repos.extend(get_branches(sources['launchpad']))
         if 'github' in sources:
             repos.extend(get_repos(sources['github'],

--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -416,6 +416,8 @@ def get_branches(sources):
 
 def get_lp_repos(sources):
     '''Return all repos, prs and reviews for the given lp-git source.'''
+    # deferred import of launchpadagent until required
+    from . import launchpadagent
     cachedir_prefix = os.environ.get('SNAP_USER_COMMON', "/tmp")
     launchpad_cachedir = os.path.join('{}/get_reviews/.launchpadlib'.format(cachedir_prefix))
     lp = launchpadagent.get_launchpad(launchpadlib_dir=launchpad_cachedir)
@@ -464,7 +466,6 @@ def aggregate_reviews(sources, output_directory, github_password, github_token,
         if 'lp-git' in sources:
             repos.extend(get_lp_repos(sources['lp-git']))
         if 'launchpad' in sources:
-            # Only import the launchpad code conditionally. This prevents having an
             # install time dependency on launchpad libs.
             from . import launchpadagent
             repos.extend(get_branches(sources['launchpad']))


### PR DESCRIPTION
This prevents the code from blowing up in case launchpadlib is not
installed (unless of course the user adds a launchpad repo to track).