### PR TITLE
Use the name of the person opening a PR as author.

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -201,7 +201,7 @@ def get_prs(gr, repo, review_count):
     pull_requests = []
     pulls = repo.get_pulls()
     for p in pulls:
-        pr = GithubPullRequest(p, p.html_url, p.title, p.head.repo.owner.login,
+        pr = GithubPullRequest(p, p.html_url, p.title, p.user.login,
                             p.state, p.created_at, review_count)
         gr.add(pr)
         pull_requests.append(pr)


### PR DESCRIPTION
This is more consistent with the github UI.

In Exoscale's case, the workflow is that developers create branches in
shared repos (as opposed to forking repositories). This change should
therefore make the owner column useful, while organisations that use the
forking workflow should see no difference (the people opening the PRs
are very very often the owner of the fork).