### PR TITLE
Reviews with "CHANGES_REQUESTED" should be red.

### DIFF
--- a/src/review_gator/templates/reviews.html
+++ b/src/review_gator/templates/reviews.html
@@ -59,8 +59,8 @@
                             <tbody>
                                 {% for review in pull_request.reviews %}
                                 <tr {% if review.state == 'Approve' or review.state == 'APPROVED' %}class="success"{% endif %}
-                                    {% if review.state == 'Disapprove' or review.state == 'Needs Fixing' %}class="danger"{% endif %}
-                                    {% if review.state == 'Needs Information' or review.state == 'CHANGES_REQUESTED' or review.state == 'COMMENTED' %}class="warning"{% endif %}>
+                                    {% if review.state == 'Disapprove' or review.state == 'Needs Fixing' or review.state == "CHANGES_REQUESTED" %}class="danger"{% endif %}
+                                    {% if review.state == 'Needs Information' or review.state == 'COMMENTED' %}class="warning"{% endif %}>
                                     <td>{{ review.owner }}</td>
                                     <td>{{ review.state }}</td>
                                     <td>{{ review.age }}</td>


### PR DESCRIPTION
Requesting changes in github should be considered "red" as for
Launchpad's "needs fixing", since it serves the same purpose.

Also, changes requested should be a strong visual reminder to fix the
problems.