### PR TITLE
github: ignore pending reviews

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -229,6 +229,8 @@ def get_prs(gr, repo, review_count):
                 pr_latest_activity = pytz.utc.localize(raw_comment.created_at)
 
         for raw_review in raw_reviews:
+            if raw_review.state == 'PENDING':
+                continue
             owner = raw_review.user.login
             review = GithubReview(raw_review, raw_review.html_url, owner,
                                   raw_review.state, raw_review.submitted_at)


### PR DESCRIPTION
Pending reviews from the holder of the Github API token are visible in
API responses but have no URL. This breaks property access later on.
Since the review is pending, ignore it.